### PR TITLE
Fix toast error

### DIFF
--- a/components/mutable-dialog.tsx
+++ b/components/mutable-dialog.tsx
@@ -15,7 +15,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog"
-import { toast } from 'sonner';
+import { toast } from "../hooks/use-toast"; // Using shadcn toast hook for notifications.
 import { ZodType } from 'zod';
 
 export interface ActionState <T>{
@@ -89,10 +89,20 @@ export default function MutableDialog<T extends FieldValues>({
 
     if (actions.success) {
       const toastMessage = actions.message;
-      toast.success(toastMessage);
+      console.log('toastMessage:', toastMessage);
+      toast({
+        title: "Success",
+        description: toastMessage,
+        variant: "default",
+      });
     } else {
       const toastMessage = actions.message;
-      toast.error(toastMessage);
+      console.log('toastMessage:', toastMessage);
+      toast({
+        title: "Error",
+        description: toastMessage || "Failed to add User",
+        variant: "destructive",
+      });
     }
     setOpen(false);
   }
@@ -121,4 +131,4 @@ export default function MutableDialog<T extends FieldValues>({
       </DialogContent>
     </Dialog>
   );
-}
+} 


### PR DESCRIPTION
*replaced sooner to shadcn toast hook
*shadcn requires manual configuration of notification properties such as title, description, and variant.
